### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 基于Laravel5.4的后台管理系统,只完成基本的用户管理，权限管理以及角色管理，其他的都还没有做。时间有限，重复的增删改查不想写了，主要用于熟练Laravel5.4和Repository中大型框架的应用。
 
-中大型框架应用【http://oomusou.io/laravel/laravel-architecture/】
+中大型框架应用【[https://old-oomusou.goodjack.tw/laravel/architecture](https://old-oomusou.goodjack.tw/laravel/architecture/)】
 
 在此基础上，完成小型项目开发工作，除了必要的角色及菜单已有的功能外，所有新开发的功能都使用简单的MVC开发
 ---


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw